### PR TITLE
Write out complete enzyme rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ That's it. That's all there is.
 The name simply derives from the Julia standard of `x_fast` for things that are approximations.
 FastPower is simply the the `^_fast` or `pow_fast` function, following the standard conventions
 developed from Base. However, this differs from the `pow_fast` you get from Base which is still
-a lot more accurate. `FastPower.fastpower` loses about 6 digits of accuracy on Float64, so it's
-about 10 digits of accuracy. For many applications, such as solving differential equations to
-6 digits of accuracy, this can 
+a lot more accurate. `FastPower.fastpower` loses about 12 digits of accuracy on Float64, so it's
+about 3-4 digits of accuracy. For many applications, such as the adaptivity algorithm when 
+solving differential equations, this can be a sufficient amount of accuracy for a power 
+function approximation.
+
+This approximation is tested for the range of `x^y` where `x>=0` and `y>=0`. If `x<=1`, then
+the approximation is accurate for very large values of `y`. If `x<100`, then the approximation
+is accurate for `y<1`. If `x>100`, or if `x` is large and `y` is large, caution should be used. 
 
 ## What about FastPow.jl?
 

--- a/ext/FastPowerEnzymeExt.jl
+++ b/ext/FastPowerEnzymeExt.jl
@@ -3,13 +3,16 @@ module FastPowerEnzymeExt
 using FastPower
 import FastPower: fastpower
 using Enzyme
+using Enzyme.EnzymeRules: FwdConfig
 
-function Enzyme.EnzymeRules.forward(func::Const{typeof(fastpower)},
+function Enzyme.EnzymeRules.forward(config::FwdConfig,
+        func::Const{typeof(FastPower.fastpower)},
         RT::Type{<:Union{Duplicated, DuplicatedNoNeed}},
         _x::Union{Const, Duplicated}, _y::Union{Const, Duplicated})
     x = _x.val
     y = _y.val
     ret = func.val(x, y)
+    T = typeof(ret)
     if !(_x isa Const) 
         dxval = _x.dval * y * (fastpower(x,y - 1))  
     else 
@@ -21,9 +24,9 @@ function Enzyme.EnzymeRules.forward(func::Const{typeof(fastpower)},
         dyval = make_zero(_y.val)
     end 
     if RT <: DuplicatedNoNeed
-        return Float32(dxval + dyval)
+        return convert(T,dxval + dyval)
     else
-        return Duplicated(ret, Float32(dxval + dyval))
+        return Duplicated(ret, convert(T, dxval + dyval))
     end
 end
 

--- a/ext/FastPowerEnzymeExt.jl
+++ b/ext/FastPowerEnzymeExt.jl
@@ -4,6 +4,46 @@ using FastPower
 import FastPower: fastpower
 using Enzyme
 
-Enzyme.Compiler.known_ops[typeof(FastPower.fastpower)] = (:pow, 2, nothing)
+function Enzyme.EnzymeRules.forward(func::Const{typeof(fastpower)},
+        RT::Type{<:Union{Duplicated, DuplicatedNoNeed}},
+        _x::Union{Const, Duplicated}, _y::Union{Const, Duplicated})
+    x = _x.val
+    y = _y.val
+    ret = func.val(x, y)
+    if !(_x isa Const) 
+        dxval = _x.dval * y * (fastpower(x,y - 1))  
+    else 
+        dxval = make_zero(_x.val)
+    end
+    if !(_y isa Const)  
+        dyval = x isa Real && x<=0 ? Base.oftype(float(x), NaN) : _y.dval*(fastpower(x,y))*log(x)
+    else 
+        dyval = make_zero(_y.val)
+    end 
+    if RT <: DuplicatedNoNeed
+        return Float32(dxval + dyval)
+    else
+        return Duplicated(ret, Float32(dxval + dyval))
+    end
+end
+
+function EnzymeRules.augmented_primal(config::Enzyme.EnzymeRules.RevConfigWidth{1}, 
+        func::Const{typeof(fastpower)}, ::Type{<:Active}, x::Active, y::Active)
+    if EnzymeRules.needs_primal(config)
+        primal = func.val(x.val, y.val)
+    else
+        primal = nothing
+    end
+    return EnzymeRules.AugmentedReturn(primal, nothing, nothing)
+end
+
+function EnzymeRules.reverse(config::Enzyme.EnzymeRules.RevConfigWidth{1}, 
+        func::Const{typeof(fastpower)}, dret::Active, tape, _x::Active, _y::Active)
+    x = _x.val
+    y = _y.val
+    dxval =  dret.val * y * (fastpower(x,y - 1))
+    dyval = x isa Real && x<=0 ? Base.oftype(float(x), NaN) : dret.val * (fastpower(x,y))*log(x)
+    return (dxval, dyval)
+end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ end
 
         x = 3.0
         y = 2.0
-        @test_skip test_forward(fastpower, RT, (x, Tx), (y, Ty), atol = 1e-10)
+        test_forward(fastpower, RT, (x, Tx), (y, Ty), atol = 1e-10)
     end
 end
 
@@ -32,7 +32,7 @@ end
     @testset for RT in (Active,), Tx in (Active,), Ty in (Active,)
         x = 2.0
         y = 3.0
-        @test_skip test_reverse(fastpower, RT, (x, Tx), (y, Ty), atol = 1e-10)
+        test_reverse(fastpower, RT, (x, Tx), (y, Ty), atol = 1e-10)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,12 @@ end
     @test fastpower(1.0, 1.0) isa Float64
     errors = [abs(^(x, y) - fastpower(x, y)) for x in 0.001:0.001:1, y in 0.08:0.001:0.5]
     @test maximum(errors) < 1e-4
+
+    errors = [abs(^(x, y) - fastpower(x, y)) for x in 0.001:0.001:1, y in 0.08:0.001:1000.0]
+    @test maximum(errors) < 1e-3
+
+    errors = [abs(^(x, y) - fastpower(x, y)) for x in 0.001:0.001:100, y in 0.08:0.001:1.0]
+    @test maximum(errors) < 1e-2
 end
 
 @testset "Fast pow - Enzyme forward rule" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ end
 
         x = 3.0
         y = 2.0
-        test_forward(fastpower, RT, (x, Tx), (y, Ty), atol = 1e-10)
+        test_forward(fastpower, RT, (x, Tx), (y, Ty), atol = 1e-1, rtol=1e-1)
     end
 end
 
@@ -32,7 +32,7 @@ end
     @testset for RT in (Active,), Tx in (Active,), Ty in (Active,)
         x = 2.0
         y = 3.0
-        test_reverse(fastpower, RT, (x, Tx), (y, Ty), atol = 1e-10)
+        test_reverse(fastpower, RT, (x, Tx), (y, Ty), atol = 1e-1, rtol=1e-1)
     end
 end
 


### PR DESCRIPTION
Current errors:

```julia
test_forward: fastpower with return activity Duplicated on (::Float64, Duplicated), (::Float64, Duplicated): Error During Test at /Users/chrisrackauckas/.julia/packages/EnzymeTestUtils/oGylR/src/test_forward.jl:71
  Got exception outside of a @test
  Current scope:
  ; Function Attrs: mustprogress nofree readonly willreturn
  define "enzyme_type"="{[-1]:Float@double}" double @preprocess_julia_call_with_kwargs_3332(double "enzyme_type"="{[-1]:Float@double}" "enzymejl_parmtype"="5519809488" "enzymejl_parmtype_ref"="0" %0, double "enzyme_type"="{[-1]:Float@double}" "enzymejl_parmtype"="5519809488" "enzymejl_parmtype_ref"="0" %1) local_unnamed_addr #5 !dbg !139 {
  top:
    %2 = call {}*** @julia.get_pgcstack() #6
    %ptls_field11 = getelementptr inbounds {}**, {}*** %2, i64 2
    %3 = bitcast {}*** %ptls_field11 to i64***
    %ptls_load1213 = load i64**, i64*** %3, align 8, !tbaa !10
    %4 = getelementptr inbounds i64*, i64** %ptls_load1213, i64 2
    %safepoint = load i64*, i64** %4, align 8, !tbaa !14
    fence syncscope("singlethread") seq_cst
    call void @julia.safepoint(i64* %safepoint) #6, !dbg !140
    fence syncscope("singlethread") seq_cst
    %5 = fcmp une double %0, 0.000000e+00, !dbg !141
    br i1 %5, label %L6, label %L54, !dbg !143

  L6:                                               ; preds = %top
    %6 = call double @llvm.fabs.f64(double %0) #6, !dbg !144
    %7 = bitcast double %6 to i64, !dbg !145
    %.not = icmp eq i64 %7, 9218868437227405312, !dbg !145
    br i1 %.not, label %L9, label %L13, !dbg !146

  L9:                                               ; preds = %L6
    %8 = call double @llvm.fabs.f64(double %1) #6, !dbg !144
    %9 = bitcast double %8 to i64, !dbg !145
    %.not14 = icmp eq i64 %9, 9218868437227405312, !dbg !145
    br i1 %.not14, label %L54, label %L13, !dbg !146

  L13:                                              ; preds = %L9, %L6
    %10 = fptrunc double %1 to float, !dbg !147
    %11 = fptrunc double %0 to float, !dbg !147
    %bitcast_coercion = bitcast float %11 to i32, !dbg !150
    %12 = lshr i32 %bitcast_coercion, 23, !dbg !152
    %13 = and i32 %12, 255, !dbg !152
    %14 = and i32 %bitcast_coercion, 4194304, !dbg !155
    %.not15 = icmp eq i32 %14, 0, !dbg !157
    br i1 %.not15, label %L33, label %L37, !dbg !156

  L33:                                              ; preds = %L13
    %15 = and i32 %bitcast_coercion, 8388607, !dbg !159
    %16 = or i32 %15, 1065353216, !dbg !161
    %17 = add nsw i32 %13, -127, !dbg !162
    br label %L40, !dbg !162

  L37:                                              ; preds = %L13
    %18 = and i32 %bitcast_coercion, 8388607, !dbg !165
    %19 = or i32 %18, 1056964608, !dbg !167
    %20 = add nsw i32 %13, -126, !dbg !168
    br label %L40, !dbg !168

  L40:                                              ; preds = %L37, %L33
    %value_phi6 = phi i32 [ %16, %L33 ], [ %19, %L37 ]
    %value_phi7 = phi i32 [ %17, %L33 ], [ %20, %L37 ]
    %bitcast_coercion8 = bitcast i32 %value_phi6 to float, !dbg !171
    %21 = fmul contract float %bitcast_coercion8, 0x3FD5B167E0000000, !dbg !173
    %22 = fadd contract float %21, 0x3FFDC11C40000000, !dbg !173
    %23 = fadd float %bitcast_coercion8, 0x3FE0C215C0000000, !dbg !175
    %24 = fdiv float %22, %23, !dbg !176
    %25 = fadd float %bitcast_coercion8, -1.000000e+00, !dbg !177
    %26 = sitofp i32 %value_phi7 to float, !dbg !179
    %27 = fmul contract float %25, %24, !dbg !184
    %28 = fadd contract float %27, %26, !dbg !184
    %29 = fmul fast float %28, %10, !dbg !185
    %30 = call fastcc float @julia_exp2_fast_3336(float %29) #7, !dbg !186
    %31 = fpext float %30 to double, !dbg !187
    br label %L54, !dbg !149

  L54:                                              ; preds = %L40, %L9, %top
    %value_phi = phi double [ %31, %L40 ], [ 0.000000e+00, %top ], [ 0x7FF0000000000000, %L9 ]
    ret double %value_phi, !dbg !140
  }

  ; Function Attrs: mustprogress nofree readonly willreturn
  define "enzyme_type"="{[-1]:Float@double}" double @preprocess_julia_call_with_kwargs_3332(double "enzyme_type"="{[-1]:Float@double}" "enzymejl_parmtype"="5519809488" "enzymejl_parmtype_ref"="0" %0, double "enzyme_type"="{[-1]:Float@double}" "enzymejl_parmtype"="5519809488" "enzymejl_parmtype_ref"="0" %1) local_unnamed_addr #5 !dbg !139 {
  top:
    %2 = call {}*** @julia.get_pgcstack() #6
    %ptls_field11 = getelementptr inbounds {}**, {}*** %2, i64 2
    %3 = bitcast {}*** %ptls_field11 to i64***
    %ptls_load1213 = load i64**, i64*** %3, align 8, !tbaa !10
    %4 = getelementptr inbounds i64*, i64** %ptls_load1213, i64 2
    %safepoint = load i64*, i64** %4, align 8, !tbaa !14
    fence syncscope("singlethread") seq_cst
    call void @julia.safepoint(i64* %safepoint) #6, !dbg !140
    fence syncscope("singlethread") seq_cst
    %5 = fcmp une double %0, 0.000000e+00, !dbg !141
    br i1 %5, label %L6, label %L54, !dbg !143

  L6:                                               ; preds = %top
    %6 = call double @llvm.fabs.f64(double %0) #6, !dbg !144
    %7 = bitcast double %6 to i64, !dbg !145
    %.not = icmp eq i64 %7, 9218868437227405312, !dbg !145
    br i1 %.not, label %L9, label %L13, !dbg !146

  L9:                                               ; preds = %L6
    %8 = call double @llvm.fabs.f64(double %1) #6, !dbg !144
    %9 = bitcast double %8 to i64, !dbg !145
    %.not14 = icmp eq i64 %9, 9218868437227405312, !dbg !145
    br i1 %.not14, label %L54, label %L13, !dbg !146

  L13:                                              ; preds = %L9, %L6
    %10 = fptrunc double %1 to float, !dbg !147
    %11 = fptrunc double %0 to float, !dbg !147
    %bitcast_coercion = bitcast float %11 to i32, !dbg !150
    %12 = lshr i32 %bitcast_coercion, 23, !dbg !152
    %13 = and i32 %12, 255, !dbg !152
    %14 = and i32 %bitcast_coercion, 4194304, !dbg !155
    %.not15 = icmp eq i32 %14, 0, !dbg !157
    br i1 %.not15, label %L33, label %L37, !dbg !156

  L33:                                              ; preds = %L13
    %15 = and i32 %bitcast_coercion, 8388607, !dbg !159
    %16 = or i32 %15, 1065353216, !dbg !161
    %17 = add nsw i32 %13, -127, !dbg !162
    br label %L40, !dbg !162

  L37:                                              ; preds = %L13
    %18 = and i32 %bitcast_coercion, 8388607, !dbg !165
    %19 = or i32 %18, 1056964608, !dbg !167
    %20 = add nsw i32 %13, -126, !dbg !168
    br label %L40, !dbg !168

  L40:                                              ; preds = %L37, %L33
    %value_phi6 = phi i32 [ %16, %L33 ], [ %19, %L37 ]
    %value_phi7 = phi i32 [ %17, %L33 ], [ %20, %L37 ]
    %bitcast_coercion8 = bitcast i32 %value_phi6 to float, !dbg !171
    %21 = fmul contract float %bitcast_coercion8, 0x3FD5B167E0000000, !dbg !173
    %22 = fadd contract float %21, 0x3FFDC11C40000000, !dbg !173
    %23 = fadd float %bitcast_coercion8, 0x3FE0C215C0000000, !dbg !175
    %24 = fdiv float %22, %23, !dbg !176
    %25 = fadd float %bitcast_coercion8, -1.000000e+00, !dbg !177
    %26 = sitofp i32 %value_phi7 to float, !dbg !179
    %27 = fmul contract float %25, %24, !dbg !184
    %28 = fadd contract float %27, %26, !dbg !184
    %29 = fmul fast float %28, %10, !dbg !185
    %30 = call fastcc float @julia_exp2_fast_3336(float %29) #7, !dbg !186
    %31 = fpext float %30 to double, !dbg !187
    br label %L54, !dbg !149

  L54:                                              ; preds = %L40, %L9, %top
    %value_phi = phi double [ %31, %L40 ], [ 0.000000e+00, %top ], [ 0x7FF0000000000000, %L9 ]
    ret double %value_phi, !dbg !140
  }

   constantarg[double %0] = 0 type: {[-1]:Float@double} - vals: {}
   constantarg[double %1] = 0 type: {[-1]:Float@double} - vals: {}
   constantinst[  %2 = call {}*** @julia.get_pgcstack() #6] = 1 val:1 type: {[-1]:Pointer, [-1,16]:Pointer}
   constantinst[  %ptls_field11 = getelementptr inbounds {}**, {}*** %2, i64 2] = 1 val:1 type: {[-1]:Pointer, [-1,0]:Pointer}
   constantinst[  %3 = bitcast {}*** %ptls_field11 to i64***] = 1 val:1 type: {[-1]:Pointer, [-1,0]:Pointer}
   constantinst[  %ptls_load1213 = load i64**, i64*** %3, align 8, !tbaa !10] = 1 val:1 type: {[-1]:Pointer}
   constantinst[  %4 = getelementptr inbounds i64*, i64** %ptls_load1213, i64 2] = 1 val:1 type: {[-1]:Pointer}
   constantinst[  %safepoint = load i64*, i64** %4, align 8, !tbaa !14] = 1 val:1 type: {}
   constantinst[  fence syncscope("singlethread") seq_cst] = 1 val:1 type: {}
   constantinst[  call void @julia.safepoint(i64* %safepoint) #6, !dbg !16] = 1 val:1 type: {}
   constantinst[  fence syncscope("singlethread") seq_cst] = 1 val:1 type: {}
   constantinst[  %5 = fcmp une double %0, 0.000000e+00, !dbg !17] = 1 val:1 type: {[-1]:Integer}
   constantinst[  br i1 %5, label %L6, label %L54, !dbg !23] = 1 val:1 type: {}
   constantinst[  %6 = call double @llvm.fabs.f64(double %0) #6, !dbg !26] = 1 val:1 type: {[-1]:Float@double}
   constantinst[  %7 = bitcast double %6 to i64, !dbg !28] = 1 val:1 type: {[-1]:Float@double}
   constantinst[  %.not = icmp eq i64 %7, 9218868437227405312, !dbg !28] = 1 val:1 type: {[-1]:Integer}
   constantinst[  br i1 %.not, label %L9, label %L13, !dbg !30] = 1 val:1 type: {}
   constantinst[  %8 = call double @llvm.fabs.f64(double %1) #6, !dbg !26] = 1 val:1 type: {[-1]:Float@double}
   constantinst[  %9 = bitcast double %8 to i64, !dbg !28] = 1 val:1 type: {[-1]:Float@double}
   constantinst[  %.not14 = icmp eq i64 %9, 9218868437227405312, !dbg !28] = 1 val:1 type: {[-1]:Integer}
   constantinst[  br i1 %.not14, label %L54, label %L13, !dbg !30] = 1 val:1 type: {}
   constantinst[  %10 = fptrunc double %1 to float, !dbg !31] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %11 = fptrunc double %0 to float, !dbg !31] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %bitcast_coercion = bitcast float %11 to i32, !dbg !36] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %12 = lshr i32 %bitcast_coercion, 23, !dbg !41] = 1 val:0 type: {}
   constantinst[  %13 = and i32 %12, 255, !dbg !41] = 1 val:1 type: {[-1]:Integer}
   constantinst[  %14 = and i32 %bitcast_coercion, 4194304, !dbg !46] = 1 val:1 type: {}
   constantinst[  %.not15 = icmp eq i32 %14, 0, !dbg !49] = 1 val:1 type: {[-1]:Integer}
   constantinst[  br i1 %.not15, label %L33, label %L37, !dbg !48] = 1 val:1 type: {}
   constantinst[  %15 = and i32 %bitcast_coercion, 8388607, !dbg !53] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %16 = or i32 %15, 1065353216, !dbg !55] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %17 = add nsw i32 %13, -127, !dbg !57] = 1 val:1 type: {[-1]:Integer}
   constantinst[  br label %L40, !dbg !57] = 1 val:1 type: {}
   constantinst[  %18 = and i32 %bitcast_coercion, 8388607, !dbg !61] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %19 = or i32 %18, 1056964608, !dbg !63] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %20 = add nsw i32 %13, -126, !dbg !64] = 1 val:1 type: {[-1]:Integer}
   constantinst[  br label %L40, !dbg !64] = 1 val:1 type: {}
   constantinst[  %value_phi6 = phi i32 [ %16, %L33 ], [ %19, %L37 ]] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %value_phi7 = phi i32 [ %17, %L33 ], [ %20, %L37 ]] = 1 val:1 type: {[-1]:Integer}
   constantinst[  %bitcast_coercion8 = bitcast i32 %value_phi6 to float, !dbg !67] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %21 = fmul contract float %bitcast_coercion8, 0x3FD5B167E0000000, !dbg !69] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %22 = fadd contract float %21, 0x3FFDC11C40000000, !dbg !69] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %23 = fadd float %bitcast_coercion8, 0x3FE0C215C0000000, !dbg !72] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %24 = fdiv float %22, %23, !dbg !74] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %25 = fadd float %bitcast_coercion8, -1.000000e+00, !dbg !76] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %26 = sitofp i32 %value_phi7 to float, !dbg !79] = 1 val:1 type: {[-1]:Float@float}
   constantinst[  %27 = fmul contract float %25, %24, !dbg !87] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %28 = fadd contract float %27, %26, !dbg !87] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %29 = fmul fast float %28, %10, !dbg !88] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %30 = call fastcc float @julia_exp2_fast_3336(float %29) #7, !dbg !91] = 0 val:0 type: {[-1]:Float@float}
   constantinst[  %31 = fpext float %30 to double, !dbg !93] = 0 val:0 type: {[-1]:Float@double}
   constantinst[  br label %L54, !dbg !35] = 1 val:1 type: {}
   constantinst[  %value_phi = phi double [ %31, %L40 ], [ 0.000000e+00, %top ], [ 0x7FF0000000000000, %L9 ]] = 0 val:0 type: {[-1]:Float@double}
   constantinst[  ret double %value_phi, !dbg !16] = 1 val:1 type: {}
  cannot handle unknown binary operator:   %18 = and i32 %bitcast_coercion, 8388607, !dbg !61

  Stacktrace:
   [1] &
     @ ./int.jl:347
   [2] fastlog2
     @ ~/.julia/dev/FastPower.jl/src/FastPower.jl:24
   [3] fastpower
     @ ~/.julia/dev/FastPower.jl/src/FastPower.jl:43
   [4] call_with_kwargs
     @ ~/.julia/packages/EnzymeTestUtils/oGylR/src/test_forward.jl:67

  Stacktrace:
    [1] |
      @ ./int.jl:372 [inlined]
    [2] fastlog2
      @ ~/.julia/dev/FastPower.jl/src/FastPower.jl:24 [inlined]
    [3] fastpower
      @ ~/.julia/dev/FastPower.jl/src/FastPower.jl:43 [inlined]
    [4] call_with_kwargs
      @ ~/.julia/packages/EnzymeTestUtils/oGylR/src/test_forward.jl:67 [inlined]
    [5] fwddiffejulia_call_with_kwargs_3332wrap
      @ ~/.julia/packages/EnzymeTestUtils/oGylR/src/test_forward.jl:0
    [6] macro expansion
      @ ~/.julia/packages/Enzyme/HXYPU/src/compiler.jl:9227 [inlined]
    [7] enzyme_call
      @ ~/.julia/packages/Enzyme/HXYPU/src/compiler.jl:8793 [inlined]
    [8] ForwardModeThunk
      @ ~/.julia/packages/Enzyme/HXYPU/src/compiler.jl:8582 [inlined]
    [9] autodiff
      @ ~/.julia/packages/Enzyme/HXYPU/src/Enzyme.jl:647 [inlined]
   [10] autodiff(::ForwardMode{true, FFIABI, false, false}, ::EnzymeTestUtils.var"#call_with_kwargs#50"{@NamedTuple{}}, ::Type{Duplicated}, ::Const{typeof(fastpower)}, ::Duplicated{Float64}, ::Duplicated{Float64})
      @ Enzyme ~/.julia/packages/Enzyme/HXYPU/src/Enzyme.jl:512
   [11] macro expansion
      @ ~/.julia/packages/EnzymeTestUtils/oGylR/src/test_forward.jl:96 [inlined]
   [12] macro expansion
      @ ~/.julia/juliaup/julia-1.10.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Test/src/Test.jl:1577 [inlined]
   [13] test_forward(::typeof(fastpower), ::Type, ::Tuple{Float64, UnionAll}, ::Vararg{Tuple{Float64, UnionAll}}; rng::Random.TaskLocalRNG, fdm::FiniteDifferences.AdaptedFiniteDifferenceMethod{5, 1, FiniteDifferences.UnadaptedFiniteDifferenceMethod{7, 5}}, fkwargs::@NamedTuple{}, rtol::Float64, atol::Float64, testset_name::Nothing, runtime_activity::Bool)
      @ EnzymeTestUtils ~/.julia/packages/EnzymeTestUtils/oGylR/src/test_forward.jl:73
   [14] macro expansion
      @ ~/.julia/dev/FastPower.jl/test/runtests.jl:27 [inlined]
   [15] macro expansion
      @ ~/.julia/juliaup/julia-1.10.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Test/src/Test.jl:1669 [inlined]
   [16] macro expansion
      @ ~/.julia/dev/FastPower.jl/test/runtests.jl:21 [inlined]
   [17] macro expansion
      @ ~/.julia/juliaup/julia-1.10.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Test/src/Test.jl:1577 [inlined]
   [18] top-level scope
      @ ~/.julia/dev/FastPower.jl/test/runtests.jl:21
   [19] include(fname::String)
      @ Base.MainInclude ./client.jl:489
   [20] top-level scope
      @ none:6
   [21] eval
      @ ./boot.jl:385 [inlined]
   [22] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:291
   [23] _start()
      @ Base ./client.jl:552
```
