### PR TITLE
Centralize CI to SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,20 +12,9 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,14 +12,10 @@ concurrency:
 jobs:
   test:
     name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
-        os: [ubuntu-latest]
+        julia-version: ["1"]
         package:
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceI}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceII}
@@ -31,42 +27,11 @@ jobs:
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: RegressionI}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: RegressionII}
           - {user: SciML, repo: SimpleDiffEq.jl, group: Core}
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-        env:
-          RETESTITEMS_NWORKERS: 4
-          RETESTITEMS_NWORKER_THREADS: 2
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      julia-arch: "x64"
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,8 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    with:
+      julia-version: "1"
+      runic-version: "1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -5,9 +5,5 @@ on: [pull_request]
 jobs:
   typos-check:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Converts the remaining inline CI workflows to the SciML centralized reusable workflows (all pinned `@v1`, every caller passes `secrets: "inherit"`). Behavior and matrices are preserved exactly.

## Converted (inline -> central)
- **FormatCheck.yml** (`format-check`): `fredrikekre/runic-action@v1` -> `runic.yml@v1` (julia-version "1", runic-version "1).
- **SpellCheck.yml** (`Spell Check`): `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`.
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1` (julia-version "1.10", skip "Pkg,TOML", allow-reresolve false). `on:` triggers (master branches, paths-ignore docs) preserved.
- **Downstream.yml** (`IntegrationTest`): inline job -> matrix of `downstream.yml@v1` callers, same 10 package+group entries (OrdinaryDiffEq.jl Interface I-V, Integrators I-II, Regression I-II; SimpleDiffEq.jl Core), julia-version 1, arch x64. Coverage/codecov now handled by the central caller.

## Already central (unchanged)
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"` (matrix version[1,lts,pre] x group[Core,Enzyme], exclude pre x Enzyme).

## Not applicable
- No `docs/` directory -> no Documentation caller.
- No AirspeedVelocity benchmark workflow -> none added.
- No CompatHelper.yml present.
- TagBot.yml unchanged.

## Other
- **dependabot.yml**: removed the `crate-ci/typos` version-ignore (no longer needed); scoped the `julia` ecosystem to `/` (the only directory with a `Project.toml`; `/test` has none). `github-actions` weekly block kept.
- **typos**: ran `typos .` clean (0 fixes).
- **Runic**: ran `Runic.main(["--inplace","."])` -> no changes (repo already Runic-clean from the prior inline check).

## Heads-up
Job/check names change with centralized callers, so any branch-protection required-status-check names will need updating after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)