### PR TITLE
Canonicalize tests to @safetestset for module isolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ Measurements = "2"
 MonteCarloMeasurements = "1"
 Mooncake = "0.4"
 ReverseDiff = "1"
+SafeTestsets = "0.1, 1"
 Tracker = "0.2"
 julia = "1.10"
 
@@ -39,8 +40,9 @@ EnzymeTestUtils = "12d8515a-0907-448a-8884-5fe00fdf1c5a"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Enzyme", "EnzymeTestUtils", "ForwardDiff", "Mooncake", "ReverseDiff", "Tracker"]
+test = ["Test", "Enzyme", "EnzymeTestUtils", "ForwardDiff", "Mooncake", "ReverseDiff", "Tracker", "SafeTestsets"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,18 @@
-using FastPower
-using FastPower: fastlog2, fastpower
-using Enzyme, EnzymeTestUtils
-using ForwardDiff, ReverseDiff, Tracker, Mooncake
-using Test
+using SafeTestsets, Test
 
-@testset "Fast log2" begin
+@safetestset "Fast log2" begin
+    using FastPower: fastlog2
+    using Test
+
     for x in 0.001:0.001:1.2 # (0, 1+something] is the domain which a controller uses
         @test log2(x)≈fastlog2(Float32(x)) atol=1e-3
     end
 end
 
-@testset "Fast pow" begin
+@safetestset "Fast pow" begin
+    using FastPower: fastpower
+    using Test
+
     @test fastpower(1, 1) isa Float64
     @test fastpower(1.0, 1.0) isa Float64
     errors = [abs(^(x, y) - fastpower(x, y)) for x in 0.001:0.001:1, y in 0.08:0.001:0.5]
@@ -23,7 +25,11 @@ end
     @test maximum(errors) < 1e-2
 end
 
-@testset "Fast pow - Enzyme forward rule" begin
+@safetestset "Fast pow - Enzyme forward rule" begin
+    using FastPower: fastpower
+    using Enzyme, EnzymeTestUtils
+    using Test
+
     @testset for RT in (Duplicated, DuplicatedNoNeed),
         Tx in (Const, Duplicated),
         Ty in (Const, Duplicated)
@@ -33,7 +39,11 @@ end
     end
 end
 
-@testset "Fast pow - Enzyme reverse rule" begin
+@safetestset "Fast pow - Enzyme reverse rule" begin
+    using FastPower: fastpower
+    using Enzyme, EnzymeTestUtils
+    using Test
+
     @testset for RT in (Active,), Tx in (Active, Const), Ty in (Active, Const)
         x = 1.0
         y = 0.5
@@ -41,10 +51,15 @@ end
     end
 end
 
-function mooncake_derivative(f, x)
-    Mooncake.value_and_gradient!!(Mooncake.build_rrule(f, x), f, x)[2][2]
-end
-@testset "Fast pow - Other AD Engines" begin
+@safetestset "Fast pow - Other AD Engines" begin
+    using FastPower: fastpower
+    using ForwardDiff, ReverseDiff, Tracker, Mooncake
+    using Test
+
+    function mooncake_derivative(f, x)
+        Mooncake.value_and_gradient!!(Mooncake.build_rrule(f, x), f, x)[2][2]
+    end
+
     x = 1.5123233245141
     y = 0.22352354326
     @test ForwardDiff.derivative(x -> fastpower(x, x + y), x) ≈


### PR DESCRIPTION
## What

Converts the independent top-level test units in `test/runtests.jl` from plain `@testset` blocks into `@safetestset` blocks, so each runs in its own freshly-generated module. This matches the canonical OrdinaryDiffEq test structure and gives per-unit isolation plus world-age safety.

## Changes

- The five units (`Fast log2`, `Fast pow`, `Fast pow - Enzyme forward rule`, `Fast pow - Enzyme reverse rule`, `Fast pow - Other AD Engines`) become `@safetestset` blocks.
- Each unit is now self-contained: the `using`/`import` lines its body relies on are copied into the block (previously these were shared module-level imports at the top of `runtests.jl`).
- The file-scope helper `mooncake_derivative` moves inside the one unit that uses it (`Fast pow - Other AD Engines`), since each `@safetestset` is its own module.
- Inner `@testset for ...` loops (Enzyme forward/reverse rules) stay as plain `@testset` — the unit-level `@safetestset` already isolates them.
- Adds `SafeTestsets` to the test deps (`[compat]`, `[extras]`, `[targets].test`).

No test logic, assertions, or test counts were changed; the GROUP/run structure is untouched (there is no GROUP ladder here).

## Verification

Verified locally with `julia +1.11`, `Pkg.test()` — all units pass with identical counts:

```
Fast log2                      | 1200  1200
Fast pow                       |    5     5
Fast pow - Enzyme forward rule |   52    52
Fast pow - Enzyme reverse rule |   36    36
Fast pow - Other AD Engines    |    4     4
     Testing FastPower tests passed
```

Ignore until reviewed by @ChrisRackauckas.