### PR TITLE
Fix Format Check: format FastPowerEnzymeExt.jl (SciMLStyle)

### DIFF
--- a/ext/FastPowerEnzymeExt.jl
+++ b/ext/FastPowerEnzymeExt.jl
@@ -5,9 +5,7 @@ import FastPower: fastpower
 using Enzyme
 using Enzyme.EnzymeRules: FwdConfig
 
-Enzyme.EnzymeRules.@easy_rule(
-    FastPower.fastpower(x, y),
-    ( y * fastpower(x, y - 1), Ω * log(x) )
-)
+Enzyme.EnzymeRules.@easy_rule(FastPower.fastpower(x, y),
+    (y * fastpower(x, y - 1), Ω * log(x)))
 
 end


### PR DESCRIPTION
## What

The `Format Check / Check Formatting` job on `main` was failing. That job runs the SciML shared workflow `SciML/.github/.github/workflows/format-check.yml@v1`, which applies JuliaFormatter v2 with `SciMLStyle()` and fails if any file changes.

Locally reproduced on Julia 1.12 (the "1" channel) with JuliaFormatter v2.8.0:

```
format(".", SciMLStyle(), verbose=true)  # => false (changes needed)
git diff --name-only                     # => ext/FastPowerEnzymeExt.jl
```

The only unformatted file was `ext/FastPowerEnzymeExt.jl` (the `@easy_rule` macro call argument layout). This PR applies the canonical formatting. Re-running the formatter afterward reports the tree as already formatted (`true`), so the Format Check will pass. The change is purely cosmetic with no semantic effect.

Note: the other red checks on `main` are downstream tests (OrdinaryDiffEq.jl, SimpleDiffEq.jl) which are out of scope for this repo's own CI.

## Local verification

- `julia +1.12` with JuliaFormatter v2.8.0 + SciMLStyle: before = needs change (only this file), after = already formatted.

Please ignore until reviewed by @ChrisRackauckas