### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ FastPower = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,13 +1,3 @@
-using FastPower
-using Aqua
-using JET
-using Test
+using SciMLTesting, FastPower, JET, Test
 
-@testset "Aqua" begin
-    Aqua.test_all(FastPower; deps_compat = (; check_extras = false))
-    @test_broken false  # Aqua deps_compat (extras): Pkg has no [compat] entry — see https://github.com/SciML/FastPower.jl/issues/53
-end
-
-@testset "JET" begin
-    JET.test_package(FastPower; target_defined_modules = true)
-end
+run_qa(FastPower; explicit_imports = true)


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Brings this repo's QA group onto the SciMLTesting **v1.6 `run_qa` form** and enables the **ExplicitImports** checks.

### `test/qa/qa.jl`
Replaces the hand-rolled `Aqua.test_all` + `JET.test_package` body with:

```julia
using SciMLTesting, FastPower, JET, Test

run_qa(FastPower; explicit_imports = true)
```

### ExplicitImports findings
FastPower's `src/FastPower.jl` imports **nothing external** (root `[deps]` is empty). All six EI checks pass with no curation:

| check | result |
|---|---|
| `no_implicit_imports` | PASS |
| `no_stale_explicit_imports` | PASS |
| `all_explicit_imports_via_owners` | PASS |
| `all_qualified_accesses_via_owners` | PASS |
| `all_qualified_accesses_are_public` | PASS |
| `all_explicit_imports_are_public` | PASS |

No `ei_kwargs` ignore-lists and no `ei_broken` needed.

### Dropped `@test_broken` (closes #53)
The old `qa.jl` carried `Aqua.test_all(FastPower; deps_compat = (; check_extras = false))` plus a `@test_broken false` for the `deps_compat` (extras) finding tracked in #53. That finding was the `Pkg` extra missing a `[compat]` entry — and `Pkg` was already removed from the root `[extras]`/test target in #54. Verified against **released SciMLTesting 1.6.0** that the full default `Aqua.test_all(FastPower)` now passes the `deps_compat` (extras) sub-check, so the marker was stale. The `check_extras = false` tweak and the `@test_broken` are both dropped (a fix, not a silenced check). **Issue #53 can be closed.**

### `test/qa/Project.toml`
- `SciMLTesting` compat `"1"` → `"1.6"`.
- `ExplicitImports` stays transitive via SciMLTesting (not listed directly).
- `Aqua` kept as a direct dep (its ambiguities sub-check child-procs and needs Aqua in the env), `JET` and `SafeTestsets` kept (`SafeTestsets` is required by the folder-model `@safetestset` wrapper).

### Verification (local)
Clean depot, **released SciMLTesting 1.6.0** (no dev-from-branch; Pkg resolved `SciMLTesting v1.6.0`), `GROUP=QA` via the `run_tests()` folder-model:

```
Test Summary: | Pass  Total   Time
QA/qa.jl      |   18     18  28.6s
```

18/18 Pass, **0 Fail / 0 Error / 0 Broken**. Aqua full-default `test_all` (8 sub-checks), JET, and all 6 EI checks confirmed individually green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)