### PR TITLE
Bump version to 1.3.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastPower"
 uuid = "a4df4552-cc26-4903-aec0-212e50a0e84b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.3.3"
+version = "1.3.4"
 
 [deps]
 


### PR DESCRIPTION
Automated patch version bump (1.3.3 -> 1.3.4) to release unreleased commits on `main` via JuliaRegistrator.