### PR TITLE
Fix downgrade workflow trigger for main

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -2,12 +2,12 @@ name: Downgrade
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Point both downgrade workflow triggers at the repository's actual default branch, `main`, instead of the retired `master` name.

The stale pull-request and push filters meant the downgrade workflow did not run for normal `main` development.

## Local verification

- Reproduced the deployed downgrade workflow locally at commit `5fdbe2bd` using Julia 1.10.11 and `julia-downgrade-compat` `fab1def`: 1,297/1,297 assertions passed across Core, AD, and Enzyme coverage.
- `Pkg.build()` passed in the exact floor environment.
- `actionlint .github/workflows/Downgrade.yml` passed.
- Runic 1.7 passed for all 15 Julia files.
- `git diff --check` passed.
