### PR TITLE
Fix relevant FastPower downstream jobs

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -22,10 +22,10 @@ jobs:
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceIII}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceIV}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceV}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: IntegratorsI}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: IntegratorsII}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: RegressionI}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: RegressionII}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Integrators_I}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Integrators_II}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression_I}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression_II}
           - {user: SciML, repo: SimpleDiffEq.jl, group: Core}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -26,7 +26,6 @@ jobs:
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Integrators_II}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression_I}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression_II}
-          - {user: SciML, repo: SimpleDiffEq.jl, group: Core}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       julia-version: "${{ matrix.julia-version }}"


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Correct the four OrdinaryDiffEq group names that lost their underscores.
- Select `Integrators_I`, `Integrators_II`, `Regression_I`, and `Regression_II` instead of silently selecting no matching branch.
- Remove the SimpleDiffEq row because SimpleDiffEq has no FastPower dependency or test reference, so developing the FastPower checkout cannot affect that lane.

The organization-wide audit found that recent green jobs for the old OrdinaryDiffEq names emitted no test summaries. It also found that the SimpleDiffEq lane was structurally irrelevant, even though it could run SimpleDiffEq tests successfully.

## Local verification

Each corrected lane was run with this FastPower branch developed into OrdinaryDiffEq:

- `GROUP=Integrators_I`: passed; final Step Limiter summary 129/129.
- `GROUP=Integrators_II`: passed after 4,992.6 seconds; final IMEX Split Function summary 15 passed, 1 pre-existing broken.
- `GROUP=Regression_I`: passed.
- `GROUP=Regression_II`: passed; IIP/OOP summary 175/175.

The final workflow also passed:

- direct assertion that all four corrected groups exist and the SimpleDiffEq row does not;
- direct recursive scan confirming SimpleDiffEq's package, source, and tests do not reference FastPower;
- `actionlint .github/workflows/Downstream.yml`;
- `julia +1.12 --startup-file=no -m Runic --check .`;
- `git diff --check`.
