### PR TITLE
Enable rendered public-docs QA for FastPower

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,3 @@
 using SciMLTesting, FastPower, JET, Test
 
-run_qa(FastPower; explicit_imports = true)
+run_qa(FastPower; explicit_imports = true, api_docs_kwargs = (; rendered = true))


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enable SciMLTesting rendered public-docs QA for FastPower.
- Audited package-owned public/exported API declarations: FastPower currently has no `export` or Julia `public` declarations, so no docs/docstrings changes are needed.
- No `[sources]` entries were added.

## Validation
- `git diff --check`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.instantiate(); include("test/qa/qa.jl")'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 -e 'using Pkg; Pkg.activate(temp=true); Pkg.add(Pkg.PackageSpec(name="Runic", version="1")); using Runic; exit(Runic.main(["--check", "."]))'`