### PR TITLE
Bump FastPower to v1.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastPower"
 uuid = "a4df4552-cc26-4903-aec0-212e50a0e84b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.3.4"
+version = "1.4.0"
 
 [deps]
 


### PR DESCRIPTION
Bumps `FastPower` **v1.3.4 → v1.4.0** (minor) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** new export `fastpower`

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)