### PR TITLE
Add PrecompileTools workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "1.4.1"
 
 [deps]
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [weakdeps]
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
@@ -29,6 +30,7 @@ ForwardDiff = "0.10, 1"
 Measurements = "2.5"
 MonteCarloMeasurements = "1"
 Mooncake = "0.4, 0.5"
+PrecompileTools = "1.2"
 ReverseDiff = "1.14"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"

--- a/src/FastPower.jl
+++ b/src/FastPower.jl
@@ -65,4 +65,15 @@ end
 
 fastpower(x, y) = x^y
 
+using PrecompileTools: @compile_workload, @setup_workload
+
+@setup_workload begin
+    @compile_workload begin
+        fastpower(1.25f0, 0.5f0)
+        fastpower(1.25, 2.0)
+        fastpower(0.0, 2.0)
+        fastpower(ComplexF64(1.25), 2.0)
+    end
+end
+
 end


### PR DESCRIPTION
## Summary
Adds a PrecompileTools workload covering representative public APIs so the package common execution path is compiled during precompilation.

## Verification
The branch was validated locally with package load/precompile, a focused workload smoke test, and repository checks where available. Runic, typos, and git diff --check were checked for the change.

## Known limitations
No additional limitation was observed in the focused verification.

This draft should be ignored until reviewed by @ChrisRackauckas.