### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastPower"
 uuid = "a4df4552-cc26-4903-aec0-212e50a0e84b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.4.1"
+version = "1.5.0"
 
 [deps]
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"


### PR DESCRIPTION
Bumps the version(s) below so the src changes already merged to `main` can be registered in the General registry.

- FastPower: 1.4.1 -> 1.5.0

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
