### PR TITLE
Drop stale [compat] majors older than one year

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ FastPowerTrackerExt = "Tracker"
 
 [compat]
 Enzyme = "0.13.89"
-ForwardDiff = "0.10, 1"
+ForwardDiff = "1"
 Measurements = "2.5"
 MonteCarloMeasurements = "1"
 Mooncake = "0.4, 0.5"


### PR DESCRIPTION
Drop `[compat]` majors whose first General-registry release is older than one year, and keep remaining floors on the latest major.

Policy: SciML minima sit on the latest majors. Extra majors first registered before 2025-08-26 are dropped. Majors first registered after that cutoff are kept (currently: OrdinaryDiffEqCore 4, LinearSolve 4, DiffEqDevTools 3). `julia` and stdlib entries are untouched.

| file | dep | before | after |
|---|---|---|---|
| `Project.toml` | `ForwardDiff` | `0.10, 1` | `1` |

OrdinaryDiffEqCore 4 / LinearSolve 4 / DiffEqDevTools 3 are kept where present because they were not in General a year ago.



This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
