### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,22 @@
+using FastPower, BenchmarkTools
+using StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+xs = rand(rng, 10_000)
+
+# =============================================================================
+# fastpower vs ^
+# =============================================================================
+
+SUITE["fastpower"] = BenchmarkGroup()
+
+SUITE["fastpower"]["int_exp"] = @benchmarkable sum(fastpower.($xs, 3))
+SUITE["fastpower"]["int_large"] = @benchmarkable sum(fastpower.($xs, 17))
+SUITE["fastpower"]["float_exp"] = @benchmarkable sum(fastpower.($xs, 2.5))
+SUITE["fastpower"]["neg_exp"] = @benchmarkable sum(fastpower.($xs, -2))
+
+SUITE["baseline"] = BenchmarkGroup()
+SUITE["baseline"]["pow3"] = @benchmarkable sum($xs .^ 3)
+SUITE["baseline"]["pow2_5"] = @benchmarkable sum($xs .^ 2.5)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~14s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~14s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md